### PR TITLE
Make watchman-processor librar-ish

### DIFF
--- a/bin/watchman-processor
+++ b/bin/watchman-processor
@@ -1,8 +1,22 @@
 #!/usr/bin/env node
 
 process.title = 'watchman-processor';
-var watchman = require('../index');
+
+var index = require('../index');
+var watchman = index.processor;
+var terminal = index.terminal;
+
 if (watchman && typeof watchman.start === 'function') {
+  watchman.emitter.on('error', function (params) {
+   terminal.error(params.err);
+  });
+  watchman.emitter.on('debug', function (params) {
+   terminal.debug(params.msg);
+  });
+  watchman.emitter.on('setState', function (params) {
+   terminal.setState(params.configEntry, params.state, params.statusMessage);
+  });
+  watchman.emitter.on('render', terminal.render.bind(terminal));
   watchman.start()
 }
 process.on('SIGINT', function() {

--- a/bin/watchman-processor
+++ b/bin/watchman-processor
@@ -5,18 +5,19 @@ process.title = 'watchman-processor';
 var index = require('../index');
 var watchman = index.processor;
 var terminal = index.terminal;
+var WatchmanProcessorEvent = index.WatchmanProcessorEvent;
 
 if (watchman && typeof watchman.start === 'function') {
-  watchman.emitter.on('error', function (params) {
+  watchman.emitter.on(WatchmanProcessorEvent.Error, function (params) {
    terminal.error(params.err);
   });
-  watchman.emitter.on('debug', function (params) {
+  watchman.emitter.on(WatchmanProcessorEvent.Debug, function (params) {
    terminal.debug(params.msg);
   });
-  watchman.emitter.on('setState', function (params) {
+  watchman.emitter.on(WatchmanProcessorEvent.SetState, function (params) {
    terminal.setState(params.configEntry, params.state, params.statusMessage);
   });
-  watchman.emitter.on('render', terminal.render.bind(terminal));
+  watchman.emitter.on(WatchmanProcessorEvent.Render, terminal.render.bind(terminal));
   watchman.start()
 }
 process.on('SIGINT', function() {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,7 @@ module.exports = {
   external: [
     'chai',
     'child_process',
+    'events',
     'fb-watchman',
     'fs',
     'inversify',

--- a/src/WatchmanProcessor.ts
+++ b/src/WatchmanProcessor.ts
@@ -69,7 +69,7 @@ export class WatchmanProcessorImpl implements WatchmanProcessor {
 
       promises.push(this.subscribe(resolvePath(sub.source), name, expression));
     }
-    const render = emitter.emit.bind(emitter, 'rednder');
+    const render = emitter.emit.bind(emitter, 'render');
     const errHandler = emitter.emit.bind(emitter, 'error');
     Promise.all(promises).then(render).catch(errHandler);
 
@@ -113,7 +113,7 @@ export class WatchmanProcessorImpl implements WatchmanProcessor {
     return new Promise<void>((resolve, reject) => {
       client.command(['subscribe', folder, name, sub],
         (error: string) => {
-          error ? reject('failed to start: ' + error) : resolve();
+          error ? reject({err: 'failed to start: ' + error, subscription: name}) : resolve();
         });
     });
   }

--- a/src/WatchmanProcessor.ts
+++ b/src/WatchmanProcessor.ts
@@ -83,20 +83,20 @@ export class WatchmanProcessorImpl implements WatchmanProcessor {
     const files = resp.files;
 
     const subConfig = config.subscriptions[subscription];
-    this.syncFiles(subConfig, files);
+    this.syncFiles(subConfig, files, subscription);
   }
 
-  private syncFiles(subConfig: SubConfig, files: SubscriptionResponseFile[]): void {
+  private syncFiles(subConfig: SubConfig, files: SubscriptionResponseFile[], subscription: string): void {
     const {sync, emitter } = this;
-    emitter.emit('setState', {configEntry: subConfig, state: 'running' });
+    emitter.emit('setState', {subscription, configEntry: subConfig, state: 'running' });
 
     const fileNames = (files || []).map(file => file.name);
     sync.syncFiles(subConfig, fileNames)
       .then(() => {
-        emitter.emit('setState', {configEntry: subConfig, state: 'good' });
+        emitter.emit('setState', {subscription, configEntry: subConfig, state: 'good' });
       })
       .catch(err => {
-        emitter.emit('setState', {configEntry: subConfig, state: 'error', statusMessage: err});
+        emitter.emit('setState', {subscription, configEntry: subConfig, state: 'error', statusMessage: err});
       });
   }
 

--- a/src/WatchmanProcessorEvent.ts
+++ b/src/WatchmanProcessorEvent.ts
@@ -1,0 +1,8 @@
+enum WatchmanProcessorEvent {
+  Debug = 'debug',
+  Error = 'error',
+  Render = 'render',
+  SetState = 'setState',
+}
+
+export {WatchmanProcessorEvent};

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ if (args.init) {
 }
 
 export default {
+  config: configManager.getConfig(),
   processor,
   terminal,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import 'reflect-metadata';
 import { Cli, ConfigManager, Terminal, WatchmanProcessor } from '../interfaces';
 import { Bindings } from './ioc.bindings';
 import { container } from './ioc.config';
+import { WatchmanProcessorEvent } from './WatchmanProcessorEvent';
 
 const cli = container.get<Cli>(Bindings.Cli);
 const configManager = container.get<ConfigManager>(Bindings.ConfigManager);
@@ -30,6 +31,7 @@ if (args.init) {
 }
 
 export default {
+  WatchmanProcessorEvent,
   config: configManager.getConfig(),
   processor,
   terminal,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 import 'reflect-metadata';
 
-import { Cli, ConfigManager, WatchmanProcessor } from '../interfaces';
+import { Cli, ConfigManager, Terminal, WatchmanProcessor } from '../interfaces';
 import { Bindings } from './ioc.bindings';
 import { container } from './ioc.config';
 
 const cli = container.get<Cli>(Bindings.Cli);
 const configManager = container.get<ConfigManager>(Bindings.ConfigManager);
 const watchmanProcessor = container.get<WatchmanProcessor>(Bindings.WatchmanProcessor);
+const terminal = container.get<Terminal>(Bindings.Terminal);
 
 const args = cli.getArguments();
 let processor = watchmanProcessor;
@@ -28,4 +29,7 @@ if (args.init) {
   }
 }
 
-export default processor;
+export default {
+  processor,
+  terminal,
+};

--- a/src/ioc.bindings.ts
+++ b/src/ioc.bindings.ts
@@ -2,6 +2,7 @@ export const Bindings = {
   Cli: Symbol('Cli'),
   Config: Symbol('Config'),
   ConfigManager: Symbol('ConfigManager'),
+  Emitter: Symbol('Emitter'),
   Process: Symbol('Process'),
   Require: Symbol('require'),
   Spawn: Symbol('spawn'),

--- a/src/ioc.config.ts
+++ b/src/ioc.config.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { EventEmitter } from 'events';
 import { Client } from 'fb-watchman';
 import { Container } from 'inversify';
 import * as interfaces from '../interfaces';
@@ -16,6 +17,7 @@ container.bind<NodeJS.Process>(Bindings.Process).toConstantValue(process);
 container.bind<interfaces.Spawn>(Bindings.Spawn).toConstantValue(spawn);
 container.bind<NodeRequire>(Bindings.Require).toConstantValue(require);
 container.bind<Client>(Bindings.WatchmanClient).toConstantValue(new Client());
+container.bind<EventEmitter>(Bindings.Emitter).toConstantValue(new EventEmitter());
 
 // setup the main classes
 container.bind<interfaces.Cli>(Bindings.Cli).to(CliImpl);

--- a/test/WatchmanProcessor-test.ts
+++ b/test/WatchmanProcessor-test.ts
@@ -74,7 +74,7 @@ describe('Watchman', () => {
     chai.assert.deepEqual(emitter.emit.getCall(1).args, ['render']);
     chai.assert.deepEqual(emitter.emit.getCall(2).args, ['debug', { msg: 'subscribe: example1' }]);
     chai.assert.deepEqual(emitter.emit.getCall(3).args, ['setState',
-      { subscription: 'example1', configEntry: config.subscriptions.example1, state: 'running' }]);
+      { configEntry: config.subscriptions.example1, state: 'running', subscription: 'example1' }]);
     chai.assert.isObject(watchman, 'watchman is an object');
   });
 

--- a/test/WatchmanProcessor-test.ts
+++ b/test/WatchmanProcessor-test.ts
@@ -7,6 +7,7 @@ import 'ts-helpers';
 import { Config } from '../interfaces';
 import { SyncImpl as Sync } from '../src/Sync';
 import { WatchmanProcessorImpl as Watchman } from '../src/WatchmanProcessor';
+import { WatchmanProcessorEvent } from '../src/WatchmanProcessorEvent';
 
 const mockEventEmitter = sinon.mock(EventEmitter);
 const emitter = mockEventEmitter as any;
@@ -54,13 +55,15 @@ describe('Watchman', () => {
   });
 
   it('should log errors from watchman.capabilityCheck', () => {
-    mockWatchmanClient.capabilityCheck.callsArgWith(1, 'error');
+    mockWatchmanClient.capabilityCheck.callsArgWith(1, WatchmanProcessorEvent.Error);
 
     const watchman = new Watchman(config, watchmanClient, emitter, sync);
     watchman.start();
 
-    chai.assert.deepEqual(emitter.emit.getCall(0).args, ['debug', { msg: 'watchman: initialize' }]);
-    chai.assert.deepEqual(emitter.emit.getCall(1).args, ['error', { err: 'error' }]);
+    chai.assert.deepEqual(
+      emitter.emit.getCall(0).args,
+      [WatchmanProcessorEvent.Debug, { msg: 'watchman: initialize' }]);
+    chai.assert.deepEqual(emitter.emit.getCall(1).args, [WatchmanProcessorEvent.Error, { err: 'error' }]);
     chai.assert.isObject(watchman, 'watchman is an object');
   });
 
@@ -70,10 +73,12 @@ describe('Watchman', () => {
     const watchman = new Watchman(config, watchmanClient, emitter, sync);
     watchman.start();
 
-    chai.assert.deepEqual(emitter.emit.getCall(0).args, ['debug', { msg: 'watchman: initialize' }]);
-    chai.assert.deepEqual(emitter.emit.getCall(1).args, ['render']);
-    chai.assert.deepEqual(emitter.emit.getCall(2).args, ['debug', { msg: 'subscribe: example1' }]);
-    chai.assert.deepEqual(emitter.emit.getCall(3).args, ['setState',
+    chai.assert.deepEqual(
+      emitter.emit.getCall(0).args,
+      [WatchmanProcessorEvent.Debug, { msg: 'watchman: initialize' }]);
+    chai.assert.deepEqual(emitter.emit.getCall(1).args, [WatchmanProcessorEvent.Render]);
+    chai.assert.deepEqual(emitter.emit.getCall(2).args, [WatchmanProcessorEvent.Debug, { msg: 'subscribe: example1' }]);
+    chai.assert.deepEqual(emitter.emit.getCall(3).args, [WatchmanProcessorEvent.SetState,
       { configEntry: config.subscriptions.example1, state: 'running', subscription: 'example1' }]);
     chai.assert.isObject(watchman, 'watchman is an object');
   });
@@ -100,7 +105,9 @@ describe('Watchman', () => {
     const watchman = new Watchman(config, watchmanClient, emitter, sync);
     watchman.end();
 
-    chai.assert.deepEqual(emitter.emit.getCall(0).args, ['debug', { msg: 'unsubscribe: example1' }]);
+    chai.assert.deepEqual(
+      emitter.emit.getCall(0).args,
+      [WatchmanProcessorEvent.Debug, { msg: 'unsubscribe: example1' }]);
   });
 
   it('should end and shutdown', () => {

--- a/test/WatchmanProcessor-test.ts
+++ b/test/WatchmanProcessor-test.ts
@@ -74,7 +74,7 @@ describe('Watchman', () => {
     chai.assert.deepEqual(emitter.emit.getCall(1).args, ['render']);
     chai.assert.deepEqual(emitter.emit.getCall(2).args, ['debug', { msg: 'subscribe: example1' }]);
     chai.assert.deepEqual(emitter.emit.getCall(3).args, ['setState',
-      { configEntry: config.subscriptions.example1, state: 'running' }]);
+      { subscription: 'example1', configEntry: config.subscriptions.example1, state: 'running' }]);
     chai.assert.isObject(watchman, 'watchman is an object');
   });
 

--- a/test/WatchmanProcessor-test.ts
+++ b/test/WatchmanProcessor-test.ts
@@ -1,15 +1,15 @@
 import * as chai from 'chai';
+import { EventEmitter } from 'events';
 import { Client } from 'fb-watchman';
 import 'reflect-metadata';
 import * as sinon from 'sinon';
 import 'ts-helpers';
 import { Config } from '../interfaces';
 import { SyncImpl as Sync } from '../src/Sync';
-import { TerminalImpl as Terminal } from '../src/Terminal';
 import { WatchmanProcessorImpl as Watchman } from '../src/WatchmanProcessor';
 
-const mockTerminal = sinon.mock(Terminal);
-const terminal: Terminal = mockTerminal as any;
+const mockEventEmitter = sinon.mock(EventEmitter);
+const emitter = mockEventEmitter as any;
 const mockSync = {
   end: sinon.stub(),
   syncFiles: sinon.stub(),
@@ -38,10 +38,7 @@ describe('Watchman', () => {
 
   beforeEach(() => {
     // mock all the defaults before
-    terminal.render = sinon.stub();
-    terminal.error = sinon.stub();
-    terminal.debug = sinon.stub();
-    terminal.setState = sinon.stub();
+    emitter.emit = sinon.spy();
 
     mockSync.syncFiles = sinon.stub().returns(new Promise(resolve => resolve()));
     mockWatchmanClient.capabilityCheck = sinon.stub().callsArg(1);
@@ -50,7 +47,7 @@ describe('Watchman', () => {
   });
 
   it('should start watchman', () => {
-    const watchman = new Watchman(config, watchmanClient, terminal, sync);
+    const watchman = new Watchman(config, watchmanClient, emitter, sync);
     watchman.start();
 
     chai.assert.isObject(watchman, 'watchman is an object');
@@ -59,25 +56,32 @@ describe('Watchman', () => {
   it('should log errors from watchman.capabilityCheck', () => {
     mockWatchmanClient.capabilityCheck.callsArgWith(1, 'error');
 
-    const watchman = new Watchman(config, watchmanClient, terminal, sync);
+    const watchman = new Watchman(config, watchmanClient, emitter, sync);
     watchman.start();
 
+    chai.assert.deepEqual(emitter.emit.getCall(0).args, ['debug', { msg: 'watchman: initialize' }]);
+    chai.assert.deepEqual(emitter.emit.getCall(1).args, ['error', { err: 'error' }]);
     chai.assert.isObject(watchman, 'watchman is an object');
   });
 
   it('should log errors from watchman.command', () => {
     mockWatchmanClient.command.callsArgWith(1, 'error');
 
-    const watchman = new Watchman(config, watchmanClient, terminal, sync);
+    const watchman = new Watchman(config, watchmanClient, emitter, sync);
     watchman.start();
 
+    chai.assert.deepEqual(emitter.emit.getCall(0).args, ['debug', { msg: 'watchman: initialize' }]);
+    chai.assert.deepEqual(emitter.emit.getCall(1).args, ['render']);
+    chai.assert.deepEqual(emitter.emit.getCall(2).args, ['debug', { msg: 'subscribe: example1' }]);
+    chai.assert.deepEqual(emitter.emit.getCall(3).args, ['setState',
+      { configEntry: config.subscriptions.example1, state: 'running' }]);
     chai.assert.isObject(watchman, 'watchman is an object');
   });
 
   it('should log errors from sync.syncFiles', () => {
     mockSync.syncFiles.returns(new Promise(() => { throw new Error('error'); }));
 
-    const watchman = new Watchman(config, watchmanClient, terminal, sync);
+    const watchman = new Watchman(config, watchmanClient, emitter, sync);
     watchman.start();
 
     chai.assert.isObject(watchman, 'watchman is an object');
@@ -85,7 +89,7 @@ describe('Watchman', () => {
 
   it('should attempt to sync files', () => {
     mockWatchmanClient.on = sinon.stub().callsArgWith(1, {subscription: 'example1'});
-    const watchman = new Watchman(config, watchmanClient, terminal, sync);
+    const watchman = new Watchman(config, watchmanClient, emitter, sync);
     watchman.start();
 
     chai.assert.isObject(watchman, 'watchman is an object');
@@ -93,14 +97,16 @@ describe('Watchman', () => {
 
   it('should end', () => {
     mockWatchmanClient.end = sinon.stub();
-    const watchman = new Watchman(config, watchmanClient, terminal, sync);
+    const watchman = new Watchman(config, watchmanClient, emitter, sync);
     watchman.end();
+
+    chai.assert.deepEqual(emitter.emit.getCall(0).args, ['debug', { msg: 'unsubscribe: example1' }]);
   });
 
   it('should end and shutdown', () => {
     mockWatchmanClient.end = sinon.stub();
     const newConfig = { controlWatchman: true, subscriptions: {} } as any;
-    const watchman = new Watchman(newConfig, watchmanClient, terminal, sync);
+    const watchman = new Watchman(newConfig, watchmanClient, emitter, sync);
     watchman.end();
   });
 


### PR DESCRIPTION
Most npm packages that run as a binary have also the ability to be imported in a project and run as a library.
It would be great if `watchman-processor` worked the same way, so that developers could extend its functionality and create new UIs or integrate it with other tools if needed. See `watchman-processor-tray-icon` [1] as an example that uses `watchman-processor` as a library to create a bitbar plugin [2] and send notifications to the notification center (see also this better implementation of a tray icon using electron [3]).

Changes summary:
1) Modify `WatchmanProcessor.ts` to emit node events instead of calling directly `Terminal.ts`;
1) In `bin/watchman-processor` listen to these events and call the corresponding `Terminal.ts` methods;
1) Update tests accordingly.

@markis, let me know if you like this idea, I think it would be a pretty powerful extension to this great package. More than happy to switch to more a appropriate architecture if needed, I kind of wanted to write down the code to convey the idea better.

[1] https://github.com/ventuno/watchman-processor-tray-icon/blob/f73d873463a3f682c649a1ca80b8b76cb2cbb11e/bitbar-plugin.js
[2] https://github.com/matryer/bitbar#writing-plugins
[3] https://github.com/ventuno/watchman-processor-tray-icon/pull/1